### PR TITLE
chtml: zero-fill omitted map values when uniform value shape is defined

### DIFF
--- a/chtml/render.go
+++ b/chtml/render.go
@@ -575,6 +575,13 @@ func matchShape(v any, shape *Shape) bool {
 						return false
 					}
 				}
+			} else if shape.Elem != nil {
+				// Check that all values match the element shape
+				for _, val := range m {
+					if !matchShape(val, shape.Elem) {
+						return false
+					}
+				}
 			}
 			return true
 		}
@@ -1015,6 +1022,12 @@ func convertToRenderShape(v any, shape *Shape) (any, error) {
 						}
 					} else {
 						m[k] = zeroValueForShape(fs)
+					}
+				}
+			} else if shape.Elem != nil {
+				for k, val := range m {
+					if conv, err := convertToRenderShape(val, shape.Elem); err == nil {
+						m[k] = conv
 					}
 				}
 			}

--- a/chtml/render_test.go
+++ b/chtml/render_test.go
@@ -996,6 +996,12 @@ func TestCElementTypeCasting(t *testing.T) {
 			vars:     nil,
 			want:     `<div><span>Text</span>123</div>`,
 		},
+		{
+			name:     "map with value shape zero-filling",
+			template: `<c var="m {_: {a: string, b: bool}}">${{"key1": {a: "val"}}}</c><p>${m.key1.a}|${m.key1.b}</p>`,
+			vars:     nil,
+			want:     `<p>val|false</p>`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When a map is defined with a uniform value shape (e.g., { _: { field: bool } }), convertToRenderShape now recursively processes each map entry to ensure missing fields are zero-filled according to the value shape. This fixes the issue where omitted boolean fields (due to omitempty) remained nil instead of being converted to false, causing type conversion errors in expressions.

Also update matchShape to validate map entries against the expected value shape.