### PR TITLE
chtml: add CHTMLScope for component invocation metadata

### DIFF
--- a/chtml/render.go
+++ b/chtml/render.go
@@ -3,6 +3,7 @@ package chtml
 import (
 	"fmt"
 	"iter"
+	"path"
 	"reflect"
 	"sort"
 	"strconv"
@@ -214,8 +215,22 @@ func (c *chtmlComponent) renderImport(n *Node) (any, error) {
 		}
 	}
 
+	ctx := CHTMLContext{
+		CallerFile: n.Source.File,
+		ImportName: strings.TrimPrefix(n.Data.RawString(), "c:"),
+	}
+	if ctx.CallerFile != "" {
+		ctx.CallerDir = path.Dir(ctx.CallerFile)
+	}
+	if ctx.ImportName == "" {
+		ctx.ImportName = n.Data.RawString()
+	}
+
 	// Create a new Scope for the imported component
 	s := c.scope.Spawn(vars)
+	if setter, ok := s.(CHTMLScopeSetter); ok {
+		setter.SetCHTMLContext(ctx)
+	}
 
 	// try to use an existing instance of the component:
 	var comp Component

--- a/chtml/render_test.go
+++ b/chtml/render_test.go
@@ -672,6 +672,58 @@ func (t *testImporter) Import(name string) (Component, error) {
 	return nil, ErrComponentNotFound
 }
 
+type captureContextComponent struct {
+	got CHTMLContext
+}
+
+var _ Component = (*captureContextComponent)(nil)
+
+func (c *captureContextComponent) Render(s Scope) (any, error) {
+	if cs, ok := s.(CHTMLScope); ok {
+		c.got = cs.CHTMLContext()
+	}
+	return nil, nil
+}
+
+func (c *captureContextComponent) InputShape() *Shape  { return nil }
+func (c *captureContextComponent) OutputShape() *Shape { return nil }
+
+type captureContextImporter struct {
+	comp *captureContextComponent
+}
+
+func (i *captureContextImporter) Import(name string) (Component, error) {
+	if name == "markdown" {
+		return i.comp, nil
+	}
+	return nil, ErrComponentNotFound
+}
+
+func TestRenderImportSetsCHTMLContext(t *testing.T) {
+	importer := &captureContextImporter{comp: &captureContextComponent{}}
+
+	doc, err := ParseWithSource("docs/page.chtml", strings.NewReader(`<c:markdown file="./README.md" />`), importer)
+	if err != nil {
+		t.Fatalf("parse with source: %v", err)
+	}
+
+	comp := NewComponent(doc, &ComponentOptions{Importer: importer})
+	if _, err := comp.Render(NewBaseScope(nil)); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	got := importer.comp.got
+	if got.CallerFile != "docs/page.chtml" {
+		t.Fatalf("caller file = %q, want %q", got.CallerFile, "docs/page.chtml")
+	}
+	if got.CallerDir != "docs" {
+		t.Fatalf("caller dir = %q, want %q", got.CallerDir, "docs")
+	}
+	if got.ImportName != "markdown" {
+		t.Fatalf("import name = %q, want %q", got.ImportName, "markdown")
+	}
+}
+
 // MyString is a custom string type for testing convertibility.
 type MyString string
 

--- a/chtml/scope.go
+++ b/chtml/scope.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 	"reflect"
 	"strconv"
 	"strings"
@@ -40,14 +41,37 @@ type Scope interface {
 	Touch()
 }
 
+// CHTMLContext describes invocation metadata for imported components.
+// CallerFile and CallerDir refer to the source component that invoked the import.
+type CHTMLContext struct {
+	CallerFile string
+	CallerDir  string
+	ImportName string
+}
+
+// CHTMLScope is an optional Scope extension that exposes invocation metadata.
+type CHTMLScope interface {
+	Scope
+	CHTMLContext() CHTMLContext
+}
+
+// CHTMLScopeSetter is an optional Scope extension used by the renderer to
+// propagate CHTML invocation metadata to child scopes.
+type CHTMLScopeSetter interface {
+	SetCHTMLContext(CHTMLContext)
+}
+
 // BaseScope is a base implementation of the Scope interface. For extra functionality, this type
 // can be wrapped (embedded) in a custom scope implementation.
 type BaseScope struct {
 	vars    map[string]any
 	touched chan struct{}
+	ctx     CHTMLContext
 }
 
 var _ Scope = (*BaseScope)(nil)
+var _ CHTMLScope = (*BaseScope)(nil)
+var _ CHTMLScopeSetter = (*BaseScope)(nil)
 
 func NewBaseScope(vars map[string]any) *BaseScope {
 	t := make(chan struct{}, 1)
@@ -62,6 +86,7 @@ func (s *BaseScope) Spawn(vars map[string]any) Scope {
 	return &BaseScope{
 		vars:    vars,
 		touched: s.touched, // all children share the same channel to notify root scope
+		ctx:     s.ctx,
 	}
 }
 
@@ -74,6 +99,18 @@ func (s *BaseScope) Touch() {
 	case s.touched <- struct{}{}:
 	default:
 	}
+}
+
+func (s *BaseScope) CHTMLContext() CHTMLContext {
+	return s.ctx
+}
+
+func (s *BaseScope) SetCHTMLContext(ctx CHTMLContext) {
+	// Derive caller directory from caller file for convenience when omitted.
+	if ctx.CallerDir == "" && ctx.CallerFile != "" {
+		ctx.CallerDir = path.Dir(ctx.CallerFile)
+	}
+	s.ctx = ctx
 }
 
 func (s *BaseScope) Touched() <-chan struct{} {

--- a/chtml/scope_test.go
+++ b/chtml/scope_test.go
@@ -72,6 +72,23 @@ func TestBaseScope_Touch(t *testing.T) {
 	}
 }
 
+func TestBaseScope_CHTMLContext(t *testing.T) {
+	parent := NewBaseScope(nil)
+	parent.SetCHTMLContext(CHTMLContext{
+		CallerFile: "docs/page.chtml",
+		ImportName: "markdown",
+	})
+
+	if got, want := parent.CHTMLContext().CallerDir, "docs"; got != want {
+		t.Fatalf("parent caller dir = %q, want %q", got, want)
+	}
+
+	child := parent.Spawn(map[string]any{}).(*BaseScope)
+	if diff := cmp.Diff(parent.CHTMLContext(), child.CHTMLContext()); diff != "" {
+		t.Fatalf("child context mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestUnmarshalScope(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Introduces CHTMLContext, CHTMLScope, and CHTMLScopeSetter interfaces to expose component invocation context (caller file/dir, import name) to imported components. This enables file-based components (e.g., c:markdown) to resolve relative paths from the importing component's location rather than requiring absolute paths.

BaseScope now implements CHTMLScope and propagates context to spawned child scopes. The renderImport path populates context from the import node's source location before calling the imported component's Render.

This is a non-breaking change; existing Scope implementations continue to work without modification.